### PR TITLE
Fixed .then duration

### DIFF
--- a/ChainableAnimations/UIViewAnimationExtensions.swift
+++ b/ChainableAnimations/UIViewAnimationExtensions.swift
@@ -39,7 +39,7 @@ public final class ChainableAnimation {
     }
     
     public func then(
-        withDuration: TimeInterval,
+        withDuration duration: TimeInterval,
         delay: TimeInterval = 0,
         options: UIView.AnimationOptions = [],
         animations: @escaping () -> Void) -> ChainableAnimation


### PR DESCRIPTION
`then` function is using the `ChainableAnimation` instance variable `duration` instead of the one given in the parameters. This makes all added animations use the same duration as the first one created on `UIView.prepareAnimation(withDuration)`.